### PR TITLE
replace travis badge with github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # random-starred-repository
 
-[![Travis Badge](https://api.travis-ci.org/vintagesucks/random-starred-repository.svg?branch=master)](https://travis-ci.org/vintagesucks/random-starred-repository) [![Dependabot Badge](https://img.shields.io/badge/Dependabot-enabled-blue.svg)](https://dependabot.com/) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo)
+[![Actions Status](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/badge/vintagesucks/random-starred-repository)](https://wdp9fww0r9.execute-api.us-west-2.amazonaws.com/production/results/vintagesucks/random-starred-repository) [![Dependabot Badge](https://img.shields.io/badge/Dependabot-enabled-blue.svg)](https://dependabot.com/) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo)
 
 Returns a random repository starred by a user
 


### PR DESCRIPTION
using https://github.com/CultureHQ/github-actions-badge until https://github.com/badges/shields/issues/2574 or something from GitHub is ready