### PR TITLE
fix TypeError if below 30 results

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ import kleur from 'kleur';
 import random from 'random';
 
 const user = process.argv.slice(2)[0];
-const randomEntry = random.int(0, 29);
 const lastPage = new RegExp(/(.*)page=(.*)>; rel="last"/);
 
 if (!user) {
@@ -39,8 +38,9 @@ const getRandomPage = user =>
 
 getRandomPage(user)
   .then(page => getStars(user, page))
+  .then(results => results[random.int(0, results.length - 1)])
   .then(result =>
     console.log(kleur.green().bold(
-      'https://github.com/' + result[randomEntry].owner + '/' + result[randomEntry].repo,
+      'https://github.com/' + result.owner + '/' + result.repo,
     )),
   );


### PR DESCRIPTION
`randomEntry` / `random.int(0, 29)` did not take into account that there may be pages with less than 30 results (e.g. last page or for users with less than 30 starred repositories)